### PR TITLE
Add missing registers for RTC peripheral

### DIFF
--- a/svd/patches/_rtc.yaml
+++ b/svd/patches/_rtc.yaml
@@ -1,0 +1,33 @@
+# https://github.com/cesanta/mongoose-os/blob/f626b5113861634e9a4acc96bdb73de29ed8a4d0/platforms/esp8266/rboot/rboot/rboot.c#L129-L135
+RTC:
+  _add:
+    PAD_XPD_DCDC_CONF:
+      access: read-write
+      addressOffset: 0xA0
+      description: PAD_XPD_DCDC_CONF
+      resetValue: 0x0
+      size: 32
+    RTC_GPIO_CONF:
+      access: read-write
+      addressOffset: 0x90
+      description: RTC_GPIO_CONF
+      resetValue: 0x0
+      size: 32
+    RTC_GPIO_ENABLE:
+      access: read-write
+      addressOffset: 0x74
+      description: RTC_GPIO_ENABLE
+      resetValue: 0x0
+      size: 32
+    RTC_GPIO_IN_DATA:
+      access: read-write
+      addressOffset: 0x8C
+      description: RTC_GPIO_IN_DATA
+      resetValue: 0x0
+      size: 32
+    RTC_GPIO_OUT:
+      access: read-write
+      addressOffset: 0x68
+      description: RTC_GPIO_OUT
+      resetValue: 0x0
+      size: 32

--- a/svd/patches/esp8266.yaml
+++ b/svd/patches/esp8266.yaml
@@ -2,10 +2,11 @@ _svd: ../esp8266.base.svd
 
 
 _include:
-  - "_io_mux.yaml"
-  - "_uart.yaml"
-  - "_timer.yaml"
-  - "_gpio.yaml"
-  - "_spi.yaml"
-  - "_misc.yaml"
   - "_dport.yaml"
+  - "_gpio.yaml"
+  - "_io_mux.yaml"
+  - "_misc.yaml"
+  - "_rtc.yaml"
+  - "_spi.yaml"
+  - "_timer.yaml"
+  - "_uart.yaml"


### PR DESCRIPTION
Non-exhaustive, but adds the registers required for an upcoming PR to the HAL which enables use of the `Gpio16` pin.