### PR TITLE
Fix addressBlock usage for I2C and RNG

### DIFF
--- a/svd/patches/_misc.yaml
+++ b/svd/patches/_misc.yaml
@@ -6,7 +6,7 @@ _add:
     addressBlock:
       offset: 0x0
       size: 32
-      usage: "RNG register"
+      usage: "registers"
     registers:
       rng:
         description: RNG register
@@ -20,7 +20,7 @@ _add:
     addressBlock:
       offset: 0x0
       size: 32
-      usage: "Internal I2C registers"
+      usage: "registers"
     registers:
       PLL:
         description: PLL I2C Register


### PR DESCRIPTION
Future versions of `svd2rust` (and the current `master` branch) will throw an error for out-of-spec `<usage/>` blocks:

```
[ERROR svd2rust] Error parsing SVD file

    Caused by:
        0: In device `esp8266`
        1: In peripheral `RNG`
        2: Parsing unknown usage at 7026:156
        3: Unknown usage variant for addressBlock
```